### PR TITLE
Add http4s client middleware, fixes #7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,8 @@ developers := List(
 
 libraryDependencies ++= Seq(
   "de.lhns" %% "fs2-compress-brotli" % "0.5.0",
-  "org.http4s" %% "http4s-core" % "0.23.19",
+  "org.http4s" %% "http4s-core"   % "0.23.19",
+  "org.http4s" %% "http4s-client" % "0.23.19",
 )
 
 addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1")

--- a/src/main/scala/de/lolhens/http4s/brotli/BrotliMiddleware.scala
+++ b/src/main/scala/de/lolhens/http4s/brotli/BrotliMiddleware.scala
@@ -1,9 +1,13 @@
 package de.lolhens.http4s.brotli
 
+import cats.ApplicativeThrow
 import cats.effect.kernel.Async
 import de.lhns.fs2.compress.BrotliDecompressor
+import fs2.{Pipe, Pull, Stream}
 import org.http4s.headers.{`Content-Encoding`, `Content-Length`}
 import org.http4s.{ContentCoding, HttpRoutes, Message, Request}
+
+import scala.util.control.NoStackTrace
 
 object BrotliMiddleware {
   def decompress[F[_] : Async](message: Message[F],
@@ -11,12 +15,28 @@ object BrotliMiddleware {
     message.headers.get[`Content-Encoding`].map(_.contentCoding) match {
       case Some(ContentCoding.br) =>
         message
-          .withBodyStream(message.body.through(BrotliDecompressor[F](chunkSize).decompress))
+          .withBodyStream(message.body.through(decompressWith(BrotliDecompressor[F](chunkSize).decompress)))
           .removeHeader[`Content-Encoding`]
           .removeHeader[`Content-Length`]
 
       case _ => message.covary
     }
+
+  private def decompressWith[F[_] : ApplicativeThrow](decompressor: Pipe[F, Byte, Byte]): Pipe[F, Byte, Byte] =
+    _.pull.peek1
+      .flatMap {
+        case None => Pull.raiseError(EmptyBodyException)
+        case Some((_, fullStream)) => Pull.output1(fullStream)
+      }
+      .stream
+      .flatten
+      .through(decompressor)
+      .handleErrorWith {
+        case EmptyBodyException => Stream.empty
+        case error => Stream.raiseError(error)
+      }
+
+  private object EmptyBodyException extends Throwable with NoStackTrace
 
   def apply[F[_] : Async](routes: HttpRoutes[F],
                           chunkSize: Int = BrotliDecompressor.defaultChunkSize): HttpRoutes[F] =

--- a/src/main/scala/de/lolhens/http4s/brotli/client/BrotliClientMiddleware.scala
+++ b/src/main/scala/de/lolhens/http4s/brotli/client/BrotliClientMiddleware.scala
@@ -1,0 +1,35 @@
+package de.lolhens.http4s.brotli.client
+
+import cats.data.NonEmptyList
+import cats.effect.kernel.Async
+import cats.syntax.all._
+import de.lhns.fs2.compress.BrotliDecompressor
+import de.lolhens.http4s.brotli.BrotliMiddleware
+import org.http4s.client.Client
+import org.http4s.headers.`Accept-Encoding`
+import org.http4s.{ContentCoding, Request}
+
+/** Client middleware for enabling brotli decompression using fs2-compress-brotli.
+  */
+object BrotliClientMiddleware {
+
+  def apply[F[_]: Async](
+    bufferSize: Int = BrotliDecompressor.defaultChunkSize
+  )(client: Client[F]): Client[F] =
+    Client[F] { req =>
+      val reqWithEncoding  = addHeaders(req)
+      val responseResource = client.run(reqWithEncoding)
+
+      responseResource.map { actualResponse =>
+        BrotliMiddleware.decompress(actualResponse, bufferSize)
+      }
+    }
+
+  private def addHeaders[F[_]](req: Request[F]): Request[F] =
+    req.headers.get[`Accept-Encoding`] match {
+      case Some(h) if h.values.contains_(ContentCoding.br) =>
+        req
+      case _                                               =>
+        req.addHeader(`Accept-Encoding`(NonEmptyList.of(ContentCoding.br)))
+    }
+}


### PR DESCRIPTION
Adds http4s client middleware in the same vein as the GZip middleware in core; adds an error handler for empty bodies to match the behaviour of the GZip middleware.